### PR TITLE
Use new onPreInit hook

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -28,7 +28,7 @@ async function calculateDirs(store) {
   }
 }
 
-exports.onPreBootstrap = async function({ store }) {
+exports.onPreInit = async function({ store }) {
   if (!process.env.NETLIFY_BUILD_BASE) {
     return
   }


### PR DESCRIPTION
It turns out some plugins expect Gatsby's cache to be available at `onPreBootstrap`, so I've opened a PR to add the `onPreInit` hook that you originally suggested :)

This updates `gatsby-plugin-netlify-cache` to use `onPreInit` instead of `onPreBootstrap`.

Don't merge until https://github.com/gatsbyjs/gatsby/pull/6387 has been merged.