### PR TITLE
feat: verbose file count

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -2,6 +2,8 @@ const { resolve, relative } = require(`path`)
 
 const { ensureDir, readdir, copy } = require(`fs-extra`)
 
+const { readFileCount } = require('./utils')
+
 async function calculateDirs(
   store,
   { extraDirsToCache = [], cachePublic = false }
@@ -44,7 +46,7 @@ function generateCacheDirectoryNames(rootDirectory, netlifyCacheDir, dirPath) {
 
 exports.onPreInit = async function(
   { store },
-  { extraDirsToCache, cachePublic }
+  { extraDirsToCache, cachePublic, verbose = false }
 ) {
   if (!process.env.NETLIFY_BUILD_BASE) {
     return
@@ -67,14 +69,23 @@ exports.onPreInit = async function(
 
     await ensureDir(cachePath)
 
-    const dirFiles = await readdir(dirPath)
-    const cacheFiles = await readdir(cachePath)
+    let dirFileCount
+    let cacheFileCount
+    if (verbose) {
+      dirFileCount = await readFileCount(dirPath)
+      cacheFileCount = await readFileCount(cachePath)
+    } else {
+      const dirFiles = await readdir(dirPath)
+      const cacheFiles = await readdir(cachePath)
+      dirFileCount = dirFiles.length
+      cacheFileCount = cacheFiles.length
+    }
 
     console.log(
       `plugin-netlify-cache: Restoring ${
-        cacheFiles.length
+        cacheFileCount
       } cached files for ${humanName} directory with ${
-        dirFiles.length
+        dirFileCount
       } already existing files.`
     )
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -45,7 +45,7 @@ function generateCacheDirectoryNames(rootDirectory, netlifyCacheDir, dirPath) {
 }
 
 exports.onPreInit = async function(
-  { store },
+  { store, reporter },
   { extraDirsToCache, cachePublic, verbose = false }
 ) {
   if (!process.env.NETLIFY_BUILD_BASE) {
@@ -81,7 +81,7 @@ exports.onPreInit = async function(
       cacheFileCount = cacheFiles.length
     }
 
-    console.log(
+    reporter.info(
       `plugin-netlify-cache: Restoring ${
         cacheFileCount
       } cached files for ${humanName} directory with ${
@@ -92,11 +92,11 @@ exports.onPreInit = async function(
     await copy(cachePath, dirPath)
   }
 
-  console.log(`plugin-netlify-cache: Netlify cache restored`)
+  reporter.success(`plugin-netlify-cache: Netlify cache restored`)
 }
 
 exports.onPostBuild = async function(
-  { store },
+  { store, reporter },
   { extraDirsToCache, cachePublic }
 ) {
   if (!process.env.NETLIFY_BUILD_BASE) {
@@ -118,10 +118,10 @@ exports.onPostBuild = async function(
       dirPath
     )
 
-    console.log(`plugin-netlify-cache: Caching ${humanName}...`)
+    reporter.info(`plugin-netlify-cache: Caching ${humanName}...`)
 
     await copy(dirPath, cachePath)
   }
 
-  console.log(`plugin-netlify-cache: Netlify cache refilled`)
+  reporter.success(`plugin-netlify-cache: Netlify cache refilled`)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,9 +9,11 @@ async function readFileCount(targetPath) {
     if (stats.isDirectory()) {
       const count = await readFileCount(filePath)
       return count
-    } else {
+    } 
+    if (stats.isFile()) {
       return 1
     }
+    return 0
   })
 
   const results = await Promise.all(countP)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,22 @@
+const fs = require(`fs-extra`)
+const path = require(`path`)
+
+async function readFileCount(targetPath) {
+  const files = await fs.readdir(targetPath)
+  const countP = files.map(async file => {
+    const filePath = path.join(targetPath, file)
+    const stats = await fs.stat(filePath)
+    if (stats.isDirectory()) {
+      const count = await readFileCount(filePath)
+      return count
+    } else {
+      return 1
+    }
+  })
+
+  const results = await Promise.all(countP)
+  const total = results.reduce((cur, acc) => (acc + cur), 0)
+  return total
+}
+
+exports.readFileCount = readFileCount


### PR DESCRIPTION
Hey @axe312ger, this PR address #22. What do you think?

- Add a `verbose` options that when enabled, will log out total amount of files instead
- Use Gatsby's `reporter` instead of `console.log`

```js
plugins: [
  {
    resolve: "gatsby-plugin-netlify-cache",
    options: {
      verbose: true
    }
  }
]
```

> info plugin-netlify-cache: Restoring 90 cached files for .cache directory with 0 already existing files.
